### PR TITLE
Fix: Ward app Uncaught TypeError: Cannot read properties of undefined (reading 'patient')

### DIFF
--- a/packages/esm-ward-app/src/hooks/useWardPatientGrouping.ts
+++ b/packages/esm-ward-app/src/hooks/useWardPatientGrouping.ts
@@ -30,11 +30,15 @@ export function useWardPatientGrouping() {
         }
       }
       for (const inpatientRequest of inpatientRequests) {
-        _patientsNotInCurrentWard.add(inpatientRequest.patient.uuid);
+        if (inpatientRequest?.patient?.uuid) {
+          _patientsNotInCurrentWard.add(inpatientRequest.patient.uuid);
+        }
       }
 
       for (const admission of inpatientAdmissions) {
-        _patientsNotInCurrentWard.delete(admission.patient.uuid);
+        if (admission?.patient?.uuid) {
+          _patientsNotInCurrentWard.delete(admission.patient.uuid);
+        }
       }
 
       return _patientsNotInCurrentWard;

--- a/packages/esm-ward-app/src/ward-view/default-ward/default-ward-pending-patients.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/default-ward/default-ward-pending-patients.component.tsx
@@ -22,29 +22,31 @@ function DefaultWardPendingPatients() {
     <ErrorState headerTitle={t('admissionRequests', 'Admission requests')} error={errorFetchingInpatientRequests} />
   ) : (
     <>
-      {inpatientRequests?.map((request: InpatientRequest, i) => {
-        const wardPatient = {
-          patient: request.patient,
-          visit: request.visit,
-          bed: null,
-          inpatientRequest: request,
-          inpatientAdmission: null,
-        };
+      {inpatientRequests
+        ?.filter((request: { patient: any }) => request?.patient)
+        .map((request: InpatientRequest, i: any) => {
+          const wardPatient = {
+            patient: request.patient,
+            visit: request.visit,
+            bed: null,
+            inpatientRequest: request,
+            inpatientAdmission: null,
+          };
 
-        return (
-          <AdmissionRequestCard
-            key={`admission-request-card-${i}`}
-            wardPatient={{
-              patient: request.patient,
-              visit: request.visit,
-              bed: null,
-              inpatientRequest: request,
-              inpatientAdmission: null,
-            }}>
-            <AdmissionRequestNoteRow id={'admission-request-note'} wardPatient={wardPatient} />
-          </AdmissionRequestCard>
-        );
-      })}
+          return (
+            <AdmissionRequestCard
+              key={`admission-request-card-${i}`}
+              wardPatient={{
+                patient: request.patient,
+                visit: request.visit,
+                bed: null,
+                inpatientRequest: request,
+                inpatientAdmission: null,
+              }}>
+              <AdmissionRequestNoteRow id={'admission-request-note'} wardPatient={wardPatient} />
+            </AdmissionRequestCard>
+          );
+        })}
     </>
   );
 }

--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -111,11 +111,11 @@ export function createAndGetWardPatientGrouping(
 
   const wardUnassignedPatientsList =
     inpatientAdmissionsAtCurrentLocation?.filter((inpatientAdmission) => {
-      allWardPatientUuids.add(inpatientAdmission.patient.uuid);
-      return (
-        !wardAdmittedPatientsWithBed.has(inpatientAdmission.patient.uuid) &&
-        !wardUnadmittedPatientsWithBed.has(inpatientAdmission.patient.uuid)
-      );
+      const patientUuid = inpatientAdmission?.patient?.uuid;
+      if (!patientUuid) return false;
+
+      allWardPatientUuids.add(patientUuid);
+      return !wardAdmittedPatientsWithBed.has(patientUuid) && !wardUnadmittedPatientsWithBed.has(patientUuid);
     }) ?? [];
 
   //excluding inpatientRequests


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The error occurs because some entries in **inpatientRequests** are `undefined` or missing the patient property, likely due to incomplete or malformed data from the server response. When the component tries to access request.patient, it throws a `TypeError` since request is undefined. This happens during `.map()` over `inpatientRequests`, and was fixed by filtering out **invalid or undefined entries** before rendering.
## Screenshots
<!-- Required if you are making UI changes. -->
![Screenshot 2025-04-15 at 6 12 47 PM](https://github.com/user-attachments/assets/1d9d3986-3f19-4e1d-94d1-b05dab2c7ef1)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://github.com/Zimhospicare/zimhospicare-core/issues/13
